### PR TITLE
Fix commit id mismatch between user and os DIRs.

### DIFF
--- a/os/usr/Makefile
+++ b/os/usr/Makefile
@@ -12,7 +12,7 @@ sfsimg := build/$(target).img
 rcore-fs-fuse:
 ifeq ($(shell which rcore-fs-fuse),)
 	@echo Installing rcore-fs-fuse
-	@cargo install rcore-fs-fuse --git https://github.com/rcore-os/rcore-fs --rev c611248
+	@cargo install rcore-fs-fuse --git https://github.com/rcore-os/rcore-fs --rev d8d6119
 endif
 
 rust:


### PR DESCRIPTION
The commit id (c611248) of rcore-fs-fuse installed by cargo in usr/Makefile  isn't match the commit id (d8d61190) of rcore-fs rcore-fs-sfs in os/Cargo.toml.

So, got the error running messages:

available programs in rust/ are:
panicked at 'failed to open SFS: WrongFs', src/libcore/result.rs:1189:5

You need to delete ~/.cargo/bin/rcore-fs-fuse, and rebuild rcore-fs-fuse by 'make rcore-fs-fuse', then 'make user_img'