### PR TITLE
Remove output of '\0' in lab-8

### DIFF
--- a/test/usr/pipe_test.rs
+++ b/test/usr/pipe_test.rs
@@ -30,10 +30,10 @@ pub fn main() -> usize {
         let ch: u8 = 0;
         loop {
             sys_read(pipefd[0] as usize, &ch as *const u8, 1);
-            string.push(ch as char);
             if ch == 0 {
                 break;
             }
+            string.push(ch as char);
         }
         println!("message received in child process = {}", string);
     } else {


### PR DESCRIPTION
The `println!("message received in child process = {}", string);` will print `^@` (ascii 0, '\0') as well. The implement of print a Rust string should print all the bytes but not stop until `\0`.

Normally the terminal will not display the ^@, but actually it has been written into stdout. But, What's more, the command `less` will display it. If we write a simple Rust program like this:
```rust
fn main() {
    let mut string = String::from("");
    string.push('A');
    string.push('\0');
    string.push('\0');
    println!("{}", string);
}
```
and run `cargo run`, it will display A. But if we use `cargo run | less`, it will display A^@^@.

So if we use `less` in the test script to show the result, we should not write '\0' into the stdout (actually `alloc::string::String` is just a `vec<u8>` and normally will not contain '\0'). Or it will make a confusing display to the students, students will use meaningless time to debug why there's ^@. (macOS terminal displays ^@, some terminal will display something messy like default terminal of Ubuntu)

Here, I change the script for not display '\0', but keep the transfer of the '\0' in pipe as the end of transfer.