### PR TITLE
docs: add tutorial repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 Please read
 - https://rcore-os.github.io/rCore_tutorial_doc/
+    - [Docs Repository](https://github.com/rcore-os/rCore_tutorial_doc)
 - https://github.com/rcore-os/rCore/wiki/os-tutorial-os2atc
 
 ## Prerequisite


### PR DESCRIPTION
Add tutorial repository link.

It's difficult to find the docs repository, so I think maybe we should add a link for it.